### PR TITLE
regarding timestamps

### DIFF
--- a/fact/dim/dim_servers.py
+++ b/fact/dim/dim_servers.py
@@ -38,7 +38,7 @@ class Dns(object):
         server_list_tuple = dic_sync_info_service(
             'DIS_DNS/SERVER_LIST',
             'C',
-            timeout=self.timeout)
+            timeout=self.timeout)['value']
         #TODO: all pydim_dic... functions have the 'timeout' parameter. (I think)
         #       and for all of them, I have to check if the return value is None.
         #       because if it is None, the function call timed out.
@@ -114,7 +114,7 @@ class DimServer(object):
         return self.__str__()
 
     def _fetch_services(self):
-        sl_raw = dic_sync_info_service(self.name + '/SERVICE_LIST', 'C', timeout=self.timeout)
+        sl_raw = dic_sync_info_service(self.name + '/SERVICE_LIST', 'C', timeout=self.timeout)['value']
         # return value is a tuple with only one element
         sl_raw = sl_raw[0]
 
@@ -167,7 +167,7 @@ class DimServer(object):
         if not self.has_service(self.name+"/SERVICE_DESC"):
             return {}
 
-        sd_raw = self.service_desc()[0]
+        sd_raw = self.service_desc()['value'][0]
         sd_raw = sd_raw.rstrip('\x00\n')
         sd = sd_raw.split('\n')
 
@@ -206,7 +206,7 @@ class DimServer(object):
 
         # there is a work around for a bug in pydim
         # even if a command needs no argument, and desc is also empty string
-        # one has to give one ... need to tell Niko about it.
+        # one still needs to give any argument ... need to tell Niko about it.
         if not fmt:
             fmt = 'I'
             args = (1, )
@@ -333,7 +333,7 @@ class FactDimServer(object):
         self.__last_service_got = time.time()
         #print 'full_srv_name',full_srv_name
         #print 'desc', desc
-        return dic_sync_info_service(full_srv_name, desc, timeout=1)
+        return dic_sync_info_service(full_srv_name, desc, timeout=1)['value']
 
     def __call__(self):
         """ Wrapper / For Convenience

--- a/fact/dim/sync_calls.py
+++ b/fact/dim/sync_calls.py
@@ -2,6 +2,12 @@ import random
 import threading
 
 from .dimc import dic_info_service, ONCE_ONLY, dic_release_service, dic_cmnd_callback
+from .dimc import (
+    dic_get_timestamp,
+    dic_get_quality,
+    dic_get_server,
+    dic_get_format
+    )
 
 
 def dic_sync_info_service(name, description, timeout=None, default_value=None):
@@ -25,11 +31,16 @@ def dic_sync_info_service(name, description, timeout=None, default_value=None):
         doesn't succeed. Optional, default is `None`.
     """
     executed = threading.Event()
-    state = dict(value=None)
+    state = dict()
 
     def create_callback(st):
         def _callback(*args):
+
             st['value'] = args
+            st['timestamp'] = dic_get_timestamp(0)
+            st['quality'] = dic_get_quality(0)
+            st['format'] = dic_get_format(0)
+            st['server'] = dic_get_server()
             executed.set()
 
         return _callback
@@ -51,7 +62,7 @@ def dic_sync_info_service(name, description, timeout=None, default_value=None):
 
     dic_release_service(sid)
 
-    return state['value']
+    return state
 
 
 def dic_sync_cmnd_service(name, arguments, description, timeout=None):


### PR DESCRIPTION
Each call to a dim-servers.service() method now not only returns the tuple of values, but a dict.
The dict is supposed to have the keys:
- 'value' --> the known tuple of values
- 'timestamp' --> 2-tuple of ("seconds since January 1, 1970", "milliseconds (a value between 0 and 999).")
- 'quality' --> an integer, known from FACT slow data fits files as 'QoS' aka 'Quality of Service'
- 'format' --> the dim-format-string of this service ... just because I can.
- 'server' --> 2-tuple of (an integer server-handle,  a string like:'MAGIC_WEATHER@10.0.100.10')

The dict may be empty in case the server didn't answer before the timeout. Should I instead throw an excpetion? (note: TimeoutError does not exist in py2.7.10, and is anyway intended to be used for low level system call timeouts). Before the method returned None, in case of a timeout.
