### PR TITLE
some new functions to help playing with bias- and trigger-patches

### DIFF
--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -13,6 +13,17 @@ pixel_mapping = np.genfromtxt(
     dtype=None,
 )
 
+non_standard_pixel_chids = dict(
+    dead=[927, 80, 873],
+    crazy=[863, 297, 868],
+    twins=[            # the signals of these pairs of pixels are the same
+        (1093, 1094),
+        (527, 528),
+        (721, 722),
+    ]
+)
+
+
 GEOM_2_SOFTID = {
     (i, j): soft for i, j, soft in zip(
         pixel_mapping['geom_i'], pixel_mapping['geom_j'], pixel_mapping['softID']

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -31,7 +31,7 @@ GEOM_2_SOFTID = {
 
 
 @lru_cache(maxsize=1)
-def pixel_dataframe():
+def get_pixel_dataframe():
     ''' return pixel mapping as pd.DataFrame
 
     '''
@@ -50,7 +50,7 @@ def pixel_dataframe():
 
     return pm
 
-patch_indices = pixel_dataframe()[[
+patch_indices = get_pixel_dataframe()[[
         'trigger_patch_id',
         'bias_patch_id',
         'bias_patch_size',

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -19,6 +19,13 @@ GEOM_2_SOFTID = {
     )}
 
 
+patch_indices = pixel_dataframe()[[
+        'trigger_patch_id',
+        'bias_patch_id',
+        'bias_patch_size',
+    ]].drop_duplicates().reset_index(drop=True, inplace=True)
+
+
 @np.vectorize
 def geom2soft(i, j):
     return GEOM_2_SOFTID[(i, j)]
@@ -140,16 +147,7 @@ def pixel_dataframe():
 
     return pm
 
-@lru_cache(maxsize=1)
-def patch_indices():
-    pi = pixel_dataframe()[[
-        'trigger_patch_id',
-        'bias_patch_id',
-        'bias_patch_size',
-    ]]
-    pi = pi.drop_duplicates()
-    pi.reset_index(drop=True, inplace=True)
-    return pi
+
 
 def combine_bias_patch_current_to_trigger_patch_current(bias_patch_currents):
     """

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -48,6 +48,12 @@ def get_pixel_dataframe():
     bias_patch_sizes = pm.bias_patch_id.value_counts().sort_index()
     pm['bias_patch_size'] = bias_patch_sizes[pm.bias_patch_id].values
 
+
+    pm['x'] = -pd.pos_Y.values*9.5
+    pm['y'] = pd.pos_X.values*9.5
+
+
+
     return pm
 
 patch_indices = get_pixel_dataframe()[[
@@ -101,7 +107,7 @@ def get_pixel_coords():
     '''
     pd = get_pixel_dataframe()
 
-    return -pd.pos_Y.values*9.5, pd.pos_X.values*9.5
+    return pd.x, pd.y
 
 
 @lru_cache(maxsize=1)

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -49,8 +49,8 @@ def get_pixel_dataframe():
     pm['bias_patch_size'] = bias_patch_sizes[pm.bias_patch_id].values
 
 
-    pm['x'] = -pd.pos_Y.values*9.5
-    pm['y'] = pd.pos_X.values*9.5
+    pm['x'] = -pm.pos_Y.values*9.5
+    pm['y'] = pm.pos_X.values*9.5
 
 
 

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -93,59 +93,15 @@ def hardid2softid(hardid):
     return chid2softid(hardid2chid(hardid))
 
 
-def get_pixel_coords(mapfile=None,
-                     rotate=True,
-                     columns=[0, 9, 10, 11],
-                     skip_header=1,
-                     skip_footer=0,
-                     delimiter=',',
-                     unpack=True,
-                     ):
+def get_pixel_coords():
     '''
     Calculate the pixel coordinates from the standard pixel-map file
     by default it gets rotated by 90 degrees clockwise to show the same
     orientation as MARS and fact-tools
-
-    Arguments
-    ---------
-    mapfile : str
-        path/to/pixelmap.csv, if None than the package resource is used
-        [defailt: None]
-    rotate : bool
-        if True the view is rotated by 90 degrees counter-clockwise
-        [default: True]
-    colums : list-like
-        the columns in the file for softID, chid, x, y
-        default: [0, 9, 10, 11]
     '''
+    pd = get_pixel_dataframe()
 
-    if mapfile is None:
-        mapfile = res.resource_filename('fact', 'resources/pixel-map.csv')
-
-    softID, chid, pixel_x_soft, pixel_y_soft = np.genfromtxt(
-        mapfile,
-        skip_header=skip_header,
-        skip_footer=skip_footer,
-        delimiter=delimiter,
-        usecols=columns,
-        unpack=unpack,
-    )
-
-    pixel_x_soft *= 9.5
-    pixel_y_soft *= 9.5
-
-    pixel_x_chid = pixel_x_soft[chid2softid(np.arange(1440))]
-    pixel_y_chid = pixel_y_soft[chid2softid(np.arange(1440))]
-
-    # rotate by 90 degrees to show correct orientation
-    if rotate is True:
-        pixel_x = - pixel_y_chid
-        pixel_y = pixel_x_chid
-    else:
-        pixel_x = pixel_x_chid
-        pixel_y = pixel_y_chid
-
-    return pixel_x, pixel_y
+    return -pd.pos_Y.values*9.5, pd.pos_X.values*9.5
 
 
 @lru_cache(maxsize=1)

--- a/fact/pixels.py
+++ b/fact/pixels.py
@@ -19,11 +19,31 @@ GEOM_2_SOFTID = {
     )}
 
 
+@lru_cache(maxsize=1)
+def pixel_dataframe():
+    ''' return pixel mapping as pd.DataFrame
+
+    '''
+    pm = pd.DataFrame(pixel_mapping)
+    pm.sort_values('hardID', inplace=True)
+    # after sorting the CHID is in principle the index
+    # of pm, but I'll like to have it explicitely
+    pm['CHID'] = np.arange(len(pm))
+
+    pm['trigger_patch_id'] = pm['CHID'] // 9
+    pm['bias_patch_id'] = (
+        pm['HV_B'] * 32 + pm['HV_C'] )
+
+    bias_patch_sizes = pm.bias_patch_id.value_counts().sort_index()
+    pm['bias_patch_size'] = bias_patch_sizes[pm.bias_patch_id].values
+
+    return pm
+
 patch_indices = pixel_dataframe()[[
         'trigger_patch_id',
         'bias_patch_id',
         'bias_patch_size',
-    ]].drop_duplicates().reset_index(drop=True, inplace=True)
+    ]].drop_duplicates().reset_index(drop=True)
 
 
 @np.vectorize
@@ -127,25 +147,6 @@ def bias_to_trigger_patch_map():
 
     return bias_channel[np.sort(idx)]
 
-@lru_cache(maxsize=1)
-def pixel_dataframe():
-    ''' return pixel mapping as pd.DataFrame
-
-    '''
-    pm = pd.DataFrame(pixel_mapping)
-    pm.sort_values('hardID', inplace=True)
-    # after sorting the CHID is in principle the index
-    # of pm, but I'll like to have it explicitely
-    pm['CHID'] = np.arange(len(pm))
-
-    pm['trigger_patch_id'] = pm['CHID'] // 9
-    pm['bias_patch_id'] = (
-        pm['HV_B'] * 32 + pm['HV_C'] )
-
-    bias_patch_sizes = pm.bias_patch_id.value_counts().sort_index()
-    pm['bias_patch_size'] = bias_patch_sizes[pm.bias_patch_id].values
-
-    return pm
 
 
 

--- a/fact/resources/known_problems_from_trac.txt
+++ b/fact/resources/known_problems_from_trac.txt
@@ -1,0 +1,91 @@
+= Old Bad Pixel =
+
+== Dead Pixels
+|| Soft ID || continuous Hard ID || Bias Ch (B/C) ||
+|| ||  ||  ||
+|| 424 || 927 || 206 (6/14) ||
+|| 923 || 80 ||  17 (0/17) ||
+|| 1208 || 873 || 194 (6/2) ||
+
+
+== Crazy Pixel
+|| Soft ID || continuous Hard ID || Bias Ch (B/C) ||
+||  ||  ||  ||
+|| 583 || 863 || 191 (5/31) ||
+|| 830 || 297 || 66 (2/2) ||
+|| 1399 || 868 || 193 (6/1) ||
+
+== Twin Pixel
+|| Soft ID || continuous Hard ID || Bias Ch(B/C) ||
+||  ||  ||  ||
+|| 113 || 1093 || 291 (9/3) ||
+|| 115 || 1094 || 291 (9/3) ||
+||  || || ||
+|| 354 || 527 || 101 (3/5) ||
+|| 423 || 528 || 101 (3/5) ||
+||  || || ||
+|| 1195 || 721 || 160 (5/0) ||
+|| 1393 || 722 || 160 (5/0) ||
+
+
+if one compares the signals of these pairs of pixels, one sees their signals only differ in their ADC digitization.
+
+= New Bad Pixel =
+
+For small time periods, two other pixels showed a wrong signal (seems to be the underflow value of the ADC)
+
+|| Soft ID || continuous Hard ID || Bias Ch(B/C) || Time Period ||
+||  ||  ||  ||  ||
+||  || 729 ||  || only on 8.1.2015 ||
+||  || 750 ||  || 8.1.2015 - 31.1.2015 ||
+
+Logbook entry of 8.1.2015:
+https://www.fact-project.org/logbook/showthread.php?tid=2943
+
+== Patch with slightly higher rate
+
+* 2|5|3 aka 103 aka 40
+
+The current readout of bias channel 262 is identical to the readout of 263. Apart from that, it seems to work fine.
+
+== Broken Drs Board ==
+
+first occurrence: 2014/11/15[[BR]]
+repaired: 2015/05/26[[BR]]
+
+pixels in affected board: [[BR]]
+SOFTIDs: 1193 1194 1195 1391 1392 1393 1304 1305 1306[[BR]]
+CHIDs: 720, 721, 722, 723, 724, 725, 726, 727, 728 (not the same order as the SOFTIDs!)
+
+Important threads:
+
+https://www.fact-project.org/logbook/showthread.php?tid=3521
+
+== Dead (and suspicious bias channels) ==
+
+With beginning of February 2015 two bias patches got some problems.
+I spot-checked the voltage curves (at interleaved lightpulser events) of the pixels and got two different behaviours:
+
+- Sometimes the pixels showed no signal at all, except for electronic noise.
+- Sometimes the pixels showed lowered signals.
+
+|| Patch CHIDs || no Bias voltage || lowered bias voltage || normal signal || comments ||
+||  ||  ||  ||  ||
+|| 171,172,173,174 || 6.2.-11.2. ; 16.2. - now || 12.2. - 14.2. || beginning - 31.1. || checked one day each month, until 2.11. ||
+|| 184,185,186,187,188 || no run found || 11.2.-13.2. ; 16.2. ; 20.2. ; 15.3. ; 20.5. ; 15.8. ; 2.11. || beginning - 15.2. ; 22.2. ; 23.2. ; 26.2. ; 10.4. ; 15.6. ; 15.7. ; 15.9. ; 14.10. || checked one day each month, until 2.11. ||
+
+Dominik showed the bias voltage of the two suspicious channels in this thread:
+
+https://www.fact-project.org/logbook/showthread.php?tid=3564&pid=19495
+
+The following two telcons have had the bias patches on the agenda:
+
+09.09.2015: https://www.fact-project.org/logbook/showthread.php?tid=3568
+
+23.09.2015: https://www.fact-project.org/logbook/showthread.php?tid=3583
+
+
+Since 13.03.2016:
+
+ * bias channel 272 (i.e. board 8, channel 16) has a shortcut ( approx 1.3 k ohms)
+

--- a/fact/resources/known_problems_from_trac.txt
+++ b/fact/resources/known_problems_from_trac.txt
@@ -1,35 +1,3 @@
-= Old Bad Pixel =
-
-== Dead Pixels
-|| Soft ID || continuous Hard ID || Bias Ch (B/C) ||
-|| ||  ||  ||
-|| 424 || 927 || 206 (6/14) ||
-|| 923 || 80 ||  17 (0/17) ||
-|| 1208 || 873 || 194 (6/2) ||
-
-
-== Crazy Pixel
-|| Soft ID || continuous Hard ID || Bias Ch (B/C) ||
-||  ||  ||  ||
-|| 583 || 863 || 191 (5/31) ||
-|| 830 || 297 || 66 (2/2) ||
-|| 1399 || 868 || 193 (6/1) ||
-
-== Twin Pixel
-|| Soft ID || continuous Hard ID || Bias Ch(B/C) ||
-||  ||  ||  ||
-|| 113 || 1093 || 291 (9/3) ||
-|| 115 || 1094 || 291 (9/3) ||
-||  || || ||
-|| 354 || 527 || 101 (3/5) ||
-|| 423 || 528 || 101 (3/5) ||
-||  || || ||
-|| 1195 || 721 || 160 (5/0) ||
-|| 1393 || 722 || 160 (5/0) ||
-
-
-if one compares the signals of these pairs of pixels, one sees their signals only differ in their ADC digitization.
-
 = New Bad Pixel =
 
 For small time periods, two other pixels showed a wrong signal (seems to be the underflow value of the ADC)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -40,7 +40,7 @@ def test_night_integer_pandas_datetimeindex():
 def test_patch_indices():
     from fact.pixels import patch_indices
 
-    pi = patch_indices()
+    pi = patch_indices
     assert pi[pi.bias_patch_id==1].trigger_patch_id.iloc[0] == 0
     assert pi[pi.bias_patch_id==128].trigger_patch_id.iloc[0] == 40
     assert pi[pi.bias_patch_id==129].trigger_patch_id.iloc[0] == 40
@@ -52,7 +52,7 @@ def test_patch_indices():
 
 def test_easier_use_of_patch_indices():
     from fact.pixels import patch_indices
-    pi = patch_indices()
+    pi = patch_indices
 
     bias_patch_ids = pi.bias_patch_id.values
 
@@ -74,7 +74,7 @@ def test_bias_patch_values_into_trigger_patches():
     # so you might start by sorting by the index you have and get the one you
     # want, like this:
     from fact.pixels import patch_indices
-    pi = patch_indices()
+    pi = patch_indices
 
     t_id_BY_b_id = pi.sort_values('bias_patch_id').trigger_patch_id.values
 
@@ -95,3 +95,14 @@ def test_bias_patch_values_into_trigger_patches():
 
 
 
+def test_coords_relation_to_pos_from_dataframe():
+
+    from fact.pixels import get_pixel_dataframe
+    from fact.pixels import get_pixel_coords
+    import numpy as np
+
+    pc = get_pixel_coords()
+    pd = get_pixel_dataframe()
+
+    assert np.allclose(pc[0], -pd.pos_Y.values*9.5)
+    assert np.allclose(pc[1], pd.pos_X.values*9.5)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -35,3 +35,63 @@ def test_night_integer_pandas_datetimeindex():
         ])
 
     assert (night_integer(dates) == [20151231, 20151231, 20160101]).all()
+
+
+def test_patch_indices():
+    from fact.pixels import patch_indices
+
+    pi = patch_indices()
+    assert pi[pi.bias_patch_id==1].trigger_patch_id.iloc[0] == 0
+    assert pi[pi.bias_patch_id==128].trigger_patch_id.iloc[0] == 40
+    assert pi[pi.bias_patch_id==129].trigger_patch_id.iloc[0] == 40
+
+    assert pi[pi.trigger_patch_id == 47].bias_patch_id.iloc[0] == 142
+    assert pi[pi.trigger_patch_id == 47].bias_patch_id.iloc[1] == 143
+    assert (pi[pi.trigger_patch_id == 47].bias_patch_id == [142, 143]).all()
+
+
+def test_easier_use_of_patch_indices():
+    from fact.pixels import patch_indices
+    pi = patch_indices()
+
+    bias_patch_ids = pi.bias_patch_id.values
+
+    # find out which are the bias patches for trigger patch 47
+    trigger_patch = 47
+    # double the number and add 0 or 1 to find both bias patch ids
+    assert bias_patch_ids[2 * trigger_patch + 0] == 142
+    assert bias_patch_ids[2 * trigger_patch + 1] == 143
+
+    t_id_BY_b_id = pi.sort_values('bias_patch_id').trigger_patch_id.values
+
+
+def test_bias_patch_values_into_trigger_patches():
+    # assume you have values sorted by bias_patch_id, e.g. currents like this:
+    #  currents = np.random.normal(loc=40, scale=10, size=320)
+    # i.e. you have 320 values and want to know which two of them
+    # should be combined into one trigger_patch.
+
+    # so you might start by sorting by the index you have and get the one you
+    # want, like this:
+    from fact.pixels import patch_indices
+    pi = patch_indices()
+
+    t_id_BY_b_id = pi.sort_values('bias_patch_id').trigger_patch_id.values
+
+    # but what does this help you? sure you can say:
+    assert t_id_BY_b_id[40] == 20
+    assert t_id_BY_b_id[41] == 20
+    assert t_id_BY_b_id[80] == 72
+    assert t_id_BY_b_id[81] == 72
+    # thus you learn that the bias patches 40 and 41 belong to
+    # trigger patch 20 (as one might have guessed)
+    # and bias_patches 80;81 belong to trigger patch 72, which one would
+    # *not* have guessed, which is why we need this mapping table.
+
+    # However it does not help you. Since you probably want this:
+    # convert the two bias currents I have for each trigger patch, into a combined
+    # value for this trigger patch.
+
+
+
+

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -93,8 +93,6 @@ def test_bias_patch_values_into_trigger_patches():
     # value for this trigger patch.
 
 
-
-
 def test_coords_relation_to_pos_from_dataframe():
 
     from fact.pixels import get_pixel_dataframe


### PR DESCRIPTION
We have twice as many bias-patches as trigger-patches in FACT, but their mapping in non trivial.
In addition when trying to combine the two "bias_patch_currents" in the one "trigger_patch_current" one needs even to know which of the two patches had 4 pixels and which had 5...

This all repeatedly kicked me in the balls so I thought it should go in here.

I also added some tests, but went crazy while writing them ... so this is not yet done, but I need it on newdaq, so I pushed it ... 

I guess the functions should not go into `fact.pixels` but somewhere else ... however implemplementing it there felt so natural, I couldn't resist.

Looking forward to your feedback.