### PR TITLE
Fix observation blocks, fix #25

### DIFF
--- a/examples/plot_qla.py
+++ b/examples/plot_qla.py
@@ -1,0 +1,14 @@
+from fact import qla
+from fact.credentials import create_factdb_engine
+import matplotlib.pyplot as plt
+
+
+db = create_factdb_engine()
+
+data = qla.get_qla_data(20161124, database=db)
+binned = qla.bin_qla_data(data, bin_width_minutes=20)
+
+qla.plot_qla(binned)
+
+plt.show()
+

--- a/fact/qla.py
+++ b/fact/qla.py
@@ -20,9 +20,8 @@ def dorner_binning(data, bin_width_minutes=20):
 def groupby_observation_blocks(runs):
     ''' Groupby for consecutive runs of the same source'''
     runs = runs.sort_values('fRunStart')
-    next_is_different = runs.fSourceName != runs.fSourceName.shift(-1)
-    next_is_different.iloc[-1] = False
-    observation_blocks = next_is_different.cumsum()
+    new_source = runs.fSourceName != runs.fSourceName.shift(1)
+    observation_blocks = new_source.cumsum()
     return runs.groupby(observation_blocks)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='pyfact',
-    version='0.8.1',
+    version='0.8.2',
     description='A module containing useful methods for working with fact',
     url='http://github.com/fact-project/pyfact',
     author='Maximilian Noethe, Dominik Neise',


### PR DESCRIPTION
This contains an important bug fix, which is critical for the flare alerts in the shifthelper.

In the change from a simple `groupby('fSourceName')` to an algorithm which can handle the same source being observed twice with another source inbetween, a bug got introduced which resulted in the first run of each source block to be assigned to the wrong source (the source observed before).

This is now fixed:

### Before
![qla_old](https://cloud.githubusercontent.com/assets/5488440/20624892/e26db3ce-b30f-11e6-8a53-85e6449d6446.png)

### Now
![qla_new](https://cloud.githubusercontent.com/assets/5488440/20624897/e97999b2-b30f-11e6-97c6-5bb0b66fb48e.png)

The results now also fit to Danielas qla plots here:
http://www.fact-project.org/monitoring/


