### PR TITLE
Fix str handling in read_h5py and read_h5py_chunked

### DIFF
--- a/fact/io.py
+++ b/fact/io.py
@@ -87,6 +87,11 @@ def read_h5py(file_path, key='data', columns=None, mode='r+'):
         df = pd.DataFrame()
         for col in columns:
             array = to_native_byteorder(group[col][:])
+
+            # pandas cannot handle bytes, convert to str
+            if array.dtype.kind == 'S':
+                array = array.astype(str)
+
             if array.ndim == 1:
                 df[col] = array
             elif array.ndim == 2:
@@ -151,6 +156,10 @@ def read_h5py_chunked(file_path, key='data', columns=None, chunksize=None, mode=
 
             for col in columns:
                 array = to_native_byteorder(group[col][start:end])
+
+                # pandas cannot handle bytes, convert to str
+                if array.dtype.kind == 'S':
+                    array = array.astype(str)
 
                 if array.ndim == 1:
                     df[col] = array

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -63,7 +63,7 @@ def test_to_h5py_datetime():
         df2 = read_h5py(f.name, key='test')
 
         for col in df2.columns:
-            df2[col] = pd.to_datetime(df2[col].apply(bytes.decode))
+            df2[col] = pd.to_datetime(df2[col])
 
         for col in df.columns:
             assert all(df[col] == df2[col])


### PR DESCRIPTION
This worked before, somehow a combination of new numpy and/or pandas versions broke bytes in DataFrames, so we convert to strings.