### PR TITLE
Ignore arrays with byteorder "not-applicable" in to_native_byteorder

### DIFF
--- a/fact/__init__.py
+++ b/fact/__init__.py
@@ -2,7 +2,7 @@ from .time import fjd, iso2dt, run2dt, facttime, night, night_integer, datestr
 from . import plotting
 from . import auxservices
 
-__version__ = '0.10.1'
+__version__ = '0.10.2'
 
 __all__ = [
     'fjd',

--- a/fact/io.py
+++ b/fact/io.py
@@ -56,7 +56,8 @@ def write_data(df, file_path, key='data', use_hp5y=False, **kwargs):
 def to_native_byteorder(array):
     ''' Convert numpy array to native byteorder '''
 
-    if array.dtype.byteorder not in ('=', native_byteorder):
+    # '|' : not-applicable, '=': native
+    if array.dtype.byteorder not in ('|', '=', native_byteorder):
         return array.byteswap().newbyteorder()
 
     return array


### PR DESCRIPTION
This fixes a bug concerning byte arrays read from h5py files. 
The `to_nativebyteorder` did not check for the `not-applicable` byteorder and switched bytes for them which caused pandas to behave strange.