### PR TITLE
Fix common kwargs for reading methods.

### DIFF
--- a/fact/io.py
+++ b/fact/io.py
@@ -176,7 +176,7 @@ def read_h5py_chunked(file_path, key='data', columns=None, chunksize=None, mode=
             yield df, start, end
 
 
-def read_data(file_path, key=None, **kwargs):
+def read_data(file_path, key=None, columns=None, **kwargs):
     '''
     This is a utility wrapper for other reading functions.
     It will look for the file extension and try to use the correct
@@ -201,11 +201,12 @@ def read_data(file_path, key=None, **kwargs):
 
     if extension in ['.hdf', '.hdf5', '.h5']:
         try:
-            df = pd.read_hdf(file_path, key=key, **kwargs)
+            df = pd.read_hdf(file_path, key=key, columns=columns, **kwargs)
         except (TypeError, ValueError):
-            df = read_h5py(file_path, key=key, **kwargs)
+            df = read_h5py(file_path, key=key, columns=columns, **kwargs)
+        return df
 
-    elif extension == '.json':
+    if extension == '.json':
         with open(file_path, 'r') as j:
             d = json.load(j)
             df = pd.DataFrame(d)
@@ -218,6 +219,9 @@ def read_data(file_path, key=None, **kwargs):
 
     else:
         raise NotImplementedError('Unknown data file extension {}'.format(extension))
+
+    if columns:
+        df = df[columns]
 
     return df
 

--- a/fact/io.py
+++ b/fact/io.py
@@ -176,7 +176,7 @@ def read_h5py_chunked(file_path, key='data', columns=None, chunksize=None, mode=
             yield df, start, end
 
 
-def read_data(file_path, **kwargs):
+def read_data(file_path, key=None, **kwargs):
     '''
     This is a utility wrapper for other reading functions.
     It will look for the file extension and try to use the correct
@@ -201,9 +201,9 @@ def read_data(file_path, **kwargs):
 
     if extension in ['.hdf', '.hdf5', '.h5']:
         try:
-            df = pd.read_hdf(file_path, **kwargs)
+            df = pd.read_hdf(file_path, key=key, **kwargs)
         except (TypeError, ValueError):
-            df = read_h5py(file_path, **kwargs)
+            df = read_h5py(file_path, key=key, **kwargs)
 
     elif extension == '.json':
         with open(file_path, 'r') as j:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -189,3 +189,42 @@ def test_write_data_root():
     with pytest.raises(IOError):
         with tempfile.NamedTemporaryFile(suffix='.root') as f:
             write_data(df, f.name)
+
+
+def test_read_data_csv():
+    '''
+    Write a csv file from a dataframe and then read it back again.
+    '''
+    from fact.io import write_data, read_data
+
+    df = pd.DataFrame({
+        'x': np.random.normal(size=50).astype('float32'),
+        'N': np.random.randint(0, 10, dtype='uint8', size=50)
+    })
+
+    with tempfile.NamedTemporaryFile(suffix='.csv') as f:
+        write_data(df, f.name)
+
+        dtypes = {'x': 'float32', 'N': 'uint8'}
+        df_from_file = read_data(f.name, dtype=dtypes)
+
+        assert df.equals(df_from_file)
+
+
+def test_read_data_h5py():
+    '''
+    Create a h5py hdf5 file from a dataframe and read it back.
+    '''
+    from fact.io import write_data, read_data
+
+    df = pd.DataFrame({
+        'x': np.random.normal(size=50).astype('float32'),
+        'N': np.random.randint(0, 10, dtype='uint8', size=50)
+    })
+
+    with tempfile.NamedTemporaryFile(suffix='.hdf5') as f:
+        write_data(df, f.name, use_h5py=True, key='lecker_daten')
+
+        df_from_file = read_data(f.name, key='lecker_daten')
+
+        assert df.equals(df_from_file)


### PR DESCRIPTION
In klaas we call `read_data` with the usual `key=...` kwargs. this fails for non-hdf5 files. This makes the key and column keyword explicit and treats them accordingly for csv files.