### PR TITLE
fact.path functions should only accept int

### DIFF
--- a/examples/path_utils.ipynb
+++ b/examples/path_utils.ipynb
@@ -100,8 +100,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The slowest run took 4.25 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
-      "100000 loops, best of 3: 3.08 µs per loop\n"
+      "The slowest run took 5.80 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "100000 loops, best of 3: 3 µs per loop\n"
      ]
     }
    ],
@@ -148,10 +148,10 @@
       "tree_path(night, run, prefix, suffix)\n",
       "    Make a tree_path from a (night, run) for given prefix, suffix\n",
       "    \n",
-      "    night: int or string\n",
-      "        eg. 20160101 or '20160101'\n",
-      "    run: int or string\n",
-      "        eg. 11 or '011' or None (int, string or None accepted)\n",
+      "    night: int\n",
+      "        eg. 20160101\n",
+      "    run: int or None\n",
+      "        eg. 11\n",
       "    prefix: string\n",
       "        eg. '/fact/raw' or '/fact/aux'\n",
       "    suffix: string\n",
@@ -168,7 +168,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -265,15 +267,15 @@
       "template_to_path(night, run, template, **kwargs)\n",
       "    Make path from template and (night, run) using kwargs existing.\n",
       "    \n",
-      "    night: int or string\n",
-      "        e.g. night = 20160102 (int)\n",
+      "    night: int\n",
+      "        e.g. night = 20160102\n",
       "        is used to create Y,M,D,N template values as:\n",
       "        Y = \"2016\"\n",
       "        M = \"01\"\n",
       "        D = \"02\"\n",
       "        N = \"20160101\"\n",
-      "    run: int or string\n",
-      "        e.g. run = 1  or run = \"000000001\"\n",
+      "    run: int or None\n",
+      "        e.g. run = 1\n",
       "        is used to create template value R = \"001\"\n",
       "    template: string\n",
       "        e.g. \"/foo/bar/{Y}/baz/{R}_{M}_{D}.gz.{N}\"\n",
@@ -292,7 +294,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/fact/auxservices/base.py
+++ b/fact/auxservices/base.py
@@ -46,4 +46,4 @@ class AuxService:
         return df
 
     def read_date(self, date):
-        return self.read_file(self.path('{:%Y%m%d}'.format(date)))
+        return self.read_file(self.path(int('{:%Y%m%d}'.format(date))))

--- a/fact/path.py
+++ b/fact/path.py
@@ -11,15 +11,15 @@ __all__ = [
 def template_to_path(night, run, template, **kwargs):
     '''Make path from template and (night, run) using kwargs existing.
 
-    night: int or string
-        e.g. night = 20160102 (int)
+    night: int
+        e.g. night = 20160102
         is used to create Y,M,D,N template values as:
         Y = "2016"
         M = "01"
         D = "02"
         N = "20160101"
-    run: int or string
-        e.g. run = 1  or run = "000000001"
+    run: int or None
+        e.g. run = 1
         is used to create template value R = "001"
     template: string
         e.g. "/foo/bar/{Y}/baz/{R}_{M}_{D}.gz.{N}"
@@ -27,9 +27,9 @@ def template_to_path(night, run, template, **kwargs):
         if template contains other place holders than Y,M,D,N,R
         kwargs are used to format these.
     '''
-    night = str(night)
+    night = '{:08d}'.format(night)
     if run is not None:
-        kwargs['R'] = '{:03d}'.format(int(run))
+        kwargs['R'] = '{:03d}'.format(run)
 
     kwargs['N'] = night
     kwargs['Y'] = night[0:4]
@@ -41,10 +41,10 @@ def template_to_path(night, run, template, **kwargs):
 def tree_path(night, run, prefix, suffix):
     '''Make a tree_path from a (night, run) for given prefix, suffix
 
-    night: int or string
-        eg. 20160101 or '20160101'
-    run: int or string
-        eg. 11 or '011' or None (int, string or None accepted)
+    night: int
+        eg. 20160101
+    run: int or None
+        eg. 11
     prefix: string
         eg. '/fact/raw' or '/fact/aux'
     suffix: string


### PR DESCRIPTION
As discussed in #74 and #75 `fact.path.`-functions should only accept ints.