### PR TITLE
Enable direct conversion from CameraFrame to ICRS

### DIFF
--- a/docs/fact.coordinates.rst
+++ b/docs/fact.coordinates.rst
@@ -1,6 +1,21 @@
 fact.coordinates package
 ========================
 
+Print the location of Crab in the camera for a given time
+
+.. code-block:: python
+
+    >>> from astropy.coordinates import SkyCoord, AltAz
+    >>> from fact.coordinates import CameraFrame
+    >>> obstime = '2013-10-03 04:00'
+    >>> crab = SkyCoord.from_name('Crab')
+    >>> pointing = AltAz(alt='62d', az='97d')
+    >>> camera_frame = CameraFrame(pointing_direction=p, obstime=obstime)
+    >>> crab_camera = crab.transform_to(camera_frame)
+    >>> print(crab_camera.x, crab_camera.y)
+    -34.79480274879211 mm 11.27416763997078 mm
+
+
 .. automodule:: fact.coordinates
     :members:
     :undoc-members:

--- a/fact/coordinates/__init__.py
+++ b/fact/coordinates/__init__.py
@@ -1,10 +1,10 @@
-from .camera_frame import CameraCoordinate
+from .camera_frame import CameraFrame
 from .utils import equatorial_to_camera, camera_to_equatorial
 from .utils import horizontal_to_camera, camera_to_horizontal
 
 
 __all__ = [
-    'CameraCoordinate',
+    'CameraFrame',
     'equatorial_to_camera',
     'camera_to_equatorial',
     'horizontal_to_camera',

--- a/fact/coordinates/camera_frame.py
+++ b/fact/coordinates/camera_frame.py
@@ -2,14 +2,14 @@ from astropy.coordinates import (
     BaseCoordinateFrame,
     AltAz,
     frame_transform_graph,
-    FunctionTransform
+    FunctionTransform,
 )
 
 try:
-    from astropy.coordinates import Attribute
+    from astropy.coordinates import Attribute, TimeAttribute
 except ImportError:
     # for astropy <= 2.0.0
-    from astropy.coordinates import FrameAttribute as Attribute
+    from astropy.coordinates import FrameAttribute as Attribute, TimeAttribute
 
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.coordinates.representation import CartesianRepresentation
@@ -22,19 +22,20 @@ import numpy as np
 focal_length = FOCAL_LENGTH_MM * u.mm
 
 
-class CameraCoordinate(BaseCoordinateFrame):
+class CameraFrame(BaseCoordinateFrame):
     '''Astropy CoordinateFrame representing coordinates in the CameraPlane'''
     default_representation = PlanarRepresentation
     pointing_direction = Attribute(default=None)
+    obstime = TimeAttribute(default=None)
 
 
-@frame_transform_graph.transform(FunctionTransform, CameraCoordinate, AltAz)
-def camera_to_altaz(camera_frame, altaz):
-    if camera_frame.pointing_direction is None:
-        raise AttributeError('Pointing Direction must be set')
+@frame_transform_graph.transform(FunctionTransform, CameraFrame, AltAz)
+def camera_to_altaz(camera, altaz):
+    if camera.pointing_direction is None:
+        raise ValueError('Pointing Direction must not be None')
 
-    x = camera_frame.x.copy()
-    y = camera_frame.y.copy()
+    x = camera.x.copy()
+    y = camera.y.copy()
 
     z = 1 / np.sqrt(1 + (x / focal_length)**2 + (y / focal_length)**2)
     x *= z / focal_length
@@ -42,8 +43,8 @@ def camera_to_altaz(camera_frame, altaz):
 
     cartesian = CartesianRepresentation(x, y, z, copy=False)
 
-    rot_z_az = rotation_matrix(-camera_frame.pointing_direction.az, 'z')
-    rot_y_zd = rotation_matrix(-camera_frame.pointing_direction.zen, 'y')
+    rot_z_az = rotation_matrix(-camera.pointing_direction.az, 'z')
+    rot_y_zd = rotation_matrix(-camera.pointing_direction.zen, 'y')
 
     cartesian = cartesian.transform(rot_y_zd)
     cartesian = cartesian.transform(rot_z_az)
@@ -52,24 +53,29 @@ def camera_to_altaz(camera_frame, altaz):
     azimuth = np.arctan2(cartesian.y, cartesian.x)
 
     return AltAz(
-        alt=altitude, az=azimuth,
+        alt=altitude,
+        az=azimuth,
         location=altaz.location,
-        obstime=altaz.obstime,
+        obstime=camera.obstime,
     )
 
 
-@frame_transform_graph.transform(FunctionTransform, AltAz, CameraCoordinate)
-def altaz_to_camera(altaz, camera_frame):
+@frame_transform_graph.transform(FunctionTransform, AltAz, CameraFrame)
+def altaz_to_camera(altaz, camera):
+    if camera.pointing_direction is None:
+        raise ValueError('Pointing Direction must not be None')
+
     cartesian = altaz.cartesian
 
-    rot_z_az = rotation_matrix(camera_frame.pointing_direction.az, 'z')
-    rot_y_zd = rotation_matrix(camera_frame.pointing_direction.zen, 'y')
+    rot_z_az = rotation_matrix(camera.pointing_direction.az, 'z')
+    rot_y_zd = rotation_matrix(camera.pointing_direction.zen, 'y')
 
     cartesian = cartesian.transform(rot_z_az)
     cartesian = cartesian.transform(rot_y_zd)
 
-    return CameraCoordinate(
+    return CameraFrame(
         x=cartesian.x * focal_length / cartesian.z,
         y=cartesian.y * focal_length / cartesian.z,
-        pointing_direction=camera_frame.pointing_direction,
+        pointing_direction=camera.pointing_direction,
+        obstime=altaz.obstime,
     )

--- a/fact/coordinates/camera_frame.py
+++ b/fact/coordinates/camera_frame.py
@@ -6,7 +6,7 @@ from astropy.coordinates import (
 )
 
 try:
-    from astropy.coordinates import Attribute, TimeAttribute
+    from astropy.coordinates import Attribute, TimeAttribute, EarthLocationAttribute
 except ImportError:
     # for astropy <= 2.0.0
     from astropy.coordinates import FrameAttribute as Attribute, TimeAttribute
@@ -16,7 +16,7 @@ from astropy.coordinates.representation import CartesianRepresentation
 import astropy.units as u
 
 from .representation import PlanarRepresentation
-from ..instrument.constants import FOCAL_LENGTH_MM
+from ..instrument.constants import FOCAL_LENGTH_MM, LOCATION
 import numpy as np
 
 focal_length = FOCAL_LENGTH_MM * u.mm
@@ -27,6 +27,7 @@ class CameraFrame(BaseCoordinateFrame):
     default_representation = PlanarRepresentation
     pointing_direction = Attribute(default=None)
     obstime = TimeAttribute(default=None)
+    location = EarthLocationAttribute(default=LOCATION)
 
 
 @frame_transform_graph.transform(FunctionTransform, CameraFrame, AltAz)
@@ -55,7 +56,7 @@ def camera_to_altaz(camera, altaz):
     return AltAz(
         alt=altitude,
         az=azimuth,
-        location=altaz.location,
+        location=camera.location,
         obstime=camera.obstime,
     )
 
@@ -78,4 +79,5 @@ def altaz_to_camera(altaz, camera):
         y=cartesian.y * focal_length / cartesian.z,
         pointing_direction=camera.pointing_direction,
         obstime=altaz.obstime,
+        location=camera.location,
     )

--- a/fact/coordinates/camera_frame.py
+++ b/fact/coordinates/camera_frame.py
@@ -6,10 +6,10 @@ from astropy.coordinates import (
 )
 
 try:
-    from astropy.coordinates import Attribute, TimeAttribute, EarthLocationAttribute
+    from astropy.coordinates import CoordinateAttribute, TimeAttribute, EarthLocationAttribute
 except ImportError:
     # for astropy <= 2.0.0
-    from astropy.coordinates import FrameAttribute as Attribute, TimeAttribute
+    from astropy.coordinates import CoordinateAttribute, TimeAttribute, EarthLocationAttribute
 
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.coordinates.representation import CartesianRepresentation
@@ -25,7 +25,7 @@ focal_length = FOCAL_LENGTH_MM * u.mm
 class CameraFrame(BaseCoordinateFrame):
     '''Astropy CoordinateFrame representing coordinates in the CameraPlane'''
     default_representation = PlanarRepresentation
-    pointing_direction = Attribute(default=None)
+    pointing_direction = CoordinateAttribute(frame=AltAz, default=None)
     obstime = TimeAttribute(default=None)
     location = EarthLocationAttribute(default=LOCATION)
 

--- a/fact/coordinates/camera_frame.py
+++ b/fact/coordinates/camera_frame.py
@@ -9,7 +9,11 @@ try:
     from astropy.coordinates import CoordinateAttribute, TimeAttribute, EarthLocationAttribute
 except ImportError:
     # for astropy <= 2.0.0
-    from astropy.coordinates import CoordinateAttribute, TimeAttribute, EarthLocationAttribute
+    from astropy.coordinates import (
+        CoordinateAttribute,
+        TimeFrameAttribute as TimeAttribute,
+        EarthLocationAttribute,
+    )
 
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.coordinates.representation import CartesianRepresentation

--- a/fact/coordinates/utils.py
+++ b/fact/coordinates/utils.py
@@ -63,11 +63,8 @@ def equatorial_to_camera(ra, dec, zd_pointing, az_pointing, observation_time):
     eq_coordinates = arrays_to_equatorial(ra, dec=dec, obstime=obstime)
     pointing_direction = arrays_to_altaz(zd_pointing, az_pointing)
 
-    altaz_frame = AltAz(location=LOCATION)
     camera_frame = CameraFrame(pointing_direction=pointing_direction)
-
-    altaz_coordinates = eq_coordinates.transform_to(altaz_frame)
-    cam_coordinates = altaz_coordinates.transform_to(camera_frame)
+    cam_coordinates = eq_coordinates.transform_to(camera_frame)
 
     return cam_coordinates.x.to(u.mm).value, cam_coordinates.y.to(u.mm).value
 
@@ -102,10 +99,7 @@ def camera_to_equatorial(x, y, zd_pointing, az_pointing, observation_time):
     obstime = Time(np.asanyarray(observation_time).astype(str))
     pointing_direction = arrays_to_altaz(zd_pointing, az_pointing)
     cam_coordinates = arrays_to_camera(x, y, pointing_direction, obstime=obstime)
-
-    altaz_frame = AltAz(location=LOCATION)
-    altaz_coordinates = cam_coordinates.transform_to(altaz_frame)
-    eq_coordinates = altaz_coordinates.transform_to(ICRS)
+    eq_coordinates = cam_coordinates.transform_to(ICRS)
 
     return eq_coordinates.ra.hourangle, eq_coordinates.dec.deg
 

--- a/tests/test_coordinate_trafos.py
+++ b/tests/test_coordinate_trafos.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+from astropy.coordinates import SkyCoord, AltAz
+import astropy.units as u
+from astropy.time import Time
+from fact.coordinates import CameraFrame
+from fact.instrument.constants import PIXEL_SPACING_MM, LOCATION, FOV_PER_PIXEL_DEG
+from pytest import approx
+
+
+obstime = Time('2014-01-01 00:00')
+altaz_frame = AltAz(location=LOCATION, obstime=obstime)
+pointing_direction = SkyCoord(
+    alt=80 * u.deg, az=-260 * u.deg,
+    frame=altaz_frame,
+)
+cam_frame = CameraFrame(pointing_direction=pointing_direction, obstime=obstime)
+
+
+def test_camera_to_altaz1():
+    c = SkyCoord(
+        x=10 * PIXEL_SPACING_MM * u.mm,
+        y=0 * u.mm,
+        frame=cam_frame,
+    )
+
+    h = c.transform_to(altaz_frame)
+    print(h.zen.deg, h.az.deg)
+    print(h.separation(pointing_direction).deg)
+    print(10 * FOV_PER_PIXEL_DEG)
+    assert h.separation(pointing_direction).deg == approx(10 * FOV_PER_PIXEL_DEG, 1e-3)
+
+
+def test_camera_to_altaz2():
+    c = SkyCoord(
+        x=-10 * PIXEL_SPACING_MM * u.mm,
+        y=0 * u.mm,
+        frame=cam_frame,
+    )
+
+    h = c.transform_to(altaz_frame)
+    print(h.zen.deg, h.az.deg)
+    print(h.separation(pointing_direction).deg)
+    assert h.separation(pointing_direction).deg == approx(10 * FOV_PER_PIXEL_DEG, 1e-3)
+
+
+def test_camera_to_altaz3():
+    c = SkyCoord(
+        x=0 * u.mm,
+        y=10 * PIXEL_SPACING_MM * u.mm,
+        frame=cam_frame,
+    )
+
+    h = c.transform_to(altaz_frame)
+    print(h.zen.deg, h.az.deg)
+    print(h.separation(pointing_direction).deg)
+    assert h.separation(pointing_direction).deg == approx(10 * FOV_PER_PIXEL_DEG, 1e-3)
+
+
+def test_camera_to_altaz4():
+    c = SkyCoord(
+        x=-10 * u.mm,
+        y=-10 * PIXEL_SPACING_MM * u.mm,
+        frame=cam_frame,
+    )
+
+    h = c.transform_to(altaz_frame)
+    print(h.zen.deg, h.az.deg)
+    print(h.separation(pointing_direction).deg)
+
+
+def test_altaz_to_camera():
+    pointing_direction = SkyCoord(
+        alt=60.667 * u.deg, az=96.790 * u.deg,
+        frame=altaz_frame,
+    )
+
+    h = SkyCoord(
+        alt=60.367 * u.deg, az=95.731 * u.deg,
+        frame=altaz_frame,
+    )
+
+    c = h.transform_to(CameraFrame(pointing_direction=pointing_direction))
+
+    print(c.x, c.y)
+
+
+if __name__ == '__main__':
+    test_camera_to_altaz1()
+    test_camera_to_altaz2()
+    test_camera_to_altaz3()
+    test_camera_to_altaz4()
+    test_altaz_to_camera()

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -45,3 +45,21 @@ def test_there_and_back_again():
 
     assert np.allclose(x, df.x)
     assert np.allclose(y, df.y)
+
+
+def test_there_and_back_again_horizontal():
+    from fact.coordinates import camera_to_horizontal, horizontal_to_camera
+
+    df = pd.DataFrame({
+        'az_tracking': [0, 90, 270],
+        'zd_tracking': [0, 10, 20],
+        'timestamp': pd.date_range('2017-10-01 22:00Z', periods=3, freq='10min'),
+        'x': [-100, 0, 150],
+        'y': [0, 100, 0],
+    })
+
+    zd, az = camera_to_horizontal(df.x, df.y, df.zd_tracking, df.az_tracking)
+    x, y = horizontal_to_camera(zd, az, df.zd_tracking, df.az_tracking)
+
+    assert np.allclose(x, df.x)
+    assert np.allclose(y, df.y)


### PR DESCRIPTION
Because of some discussion I now better understand how observation times and Coordinate trafos should be handled in astropy. These changes reflect this.

* I renamed CameraCoordinate to CameraFrame, because, well, it's a Frame
* `CameraFrame` has to new Attributes, `obstime` and `location`. This enables direct conversion from 
a `CameraCoordinate` to the equatorial coordinates and vice versa.


So to get the position of Crab in the camera, you can do now:

```python
from fact.coordinates import CameraFrame
from astropy.coordinates import SkyCoordinate, AltAz

crab = SkyCoordinate.from_name('Crab')
pointing = AltAz(alt='62d', az='97d')
crab_camera = crab.transform_to(CameraFrame(
    pointing_direction=pointing,
    obstime='2013-10-03 04:00',
))

print(crab_camera.x, crab_camera.y)
```
Which results in
```
-34.79480274879211 mm 11.27416763997078 mm
```

Which I think is pretty awesome
