### PR TITLE
warn missing x_scatter in read simulated spectrum instead of exception

### DIFF
--- a/fact/io.py
+++ b/fact/io.py
@@ -1,3 +1,4 @@
+import warnings
 from os import path
 import pandas as pd
 import json
@@ -509,11 +510,12 @@ def read_simulated_spectrum(corsika_headers_path):
             r = f['corsika_runs'].attrs.get('scatter_radius')
             unit = f['corsika_runs'].attrs.get('scatter_radius_unit', u.m)
             if r is None:
-                raise ValueError(
+                warnings.warn(
                     'File does neither contain column `/corsika_runs/x_scatter` '
                     'nor the attribute `scatter_radius`'
                 )
-            summary['x_scatter'] = u.Quantity(r, u.m)
+            else:
+                summary['x_scatter'] = u.Quantity(r, u.m)
 
     for key, unit in keys.items():
         unique_values = runs[key].unique()


### PR DESCRIPTION
warn missing x_scatter in read simulated spectrum instead of raising an exception. This is needed for old MMCs corsikas who do not have this attribute